### PR TITLE
Train model fixes

### DIFF
--- a/integration/Main.java
+++ b/integration/Main.java
@@ -64,22 +64,23 @@ public class Main
 		// mboCont = new MboController("green");
 		// mboSched = new MboScheduler("green");
 
-		// FIXME: see imports above
-		TrainController[] trainControllers = {
-			new TrainController(),
-		};
+		final int numberOfTrains = 1;
 
-		TrainModel[] trainModels = {
-			new TrainModel(),
-		};
+		TrainController[] trainControllers =
+			new TrainController[numberOfTrains];
 
-		if (trainControllers.length != trainModels.length)
-			throw new RuntimeException("mismatched train modules");
+		TrainModel[] trainModels =
+			new TrainModel[numberOfTrains];
+
+		for (int i = 0; i < numberOfTrains; ++i)
+		{
+			trainControllers[i] = new TrainController();
+			trainModels[i] = new TrainModel(i);
+		}
 
 		ArrayList<Updateable> trainObjects =
 			new ArrayList<Updateable>();
 
-		// FIXME: see instantiation above
 		trainObjects.addAll(Arrays.asList(trainControllers));
 		trainObjects.addAll(Arrays.asList(trainModels));
 

--- a/train_model/PointMass.java
+++ b/train_model/PointMass.java
@@ -64,6 +64,15 @@ public class PointMass
 		return new Pose(pose);
 	}
 
+	// Sets a new pose instantaneously.
+	//
+	// Sets the speed to zero.
+	public void slew(Pose pose)
+	{
+		this.pose = new Pose(pose);
+		this.speed = 0.0;
+	}
+
 	// Returns the current speed.
 	//
 	// Units: meters per second

--- a/train_model/TrainModel.java
+++ b/train_model/TrainModel.java
@@ -81,6 +81,9 @@ public class TrainModel
 	// notify observers once every this many updates
 	private static int NOTIFY_OBSERVERS_MOD = 2;
 
+	// identifier
+	private final int id;
+
 	private final PointMass pointMass =
 		new PointMass(MASS_EMPTY, INITIAL_POSE);
 
@@ -109,6 +112,18 @@ public class TrainModel
 	private final MboRadio mboRadio = new MboRadio(relay);
 
 	private int notifyObserversCount = 0;
+
+	// Constructs a TrainModel with the given identifier.
+	public TrainModel(int id)
+	{
+		this.id = id;
+	}
+
+	// Returns this train's identifier.
+	public int id()
+	{
+		return id;
+	}
 
 	// Returns a train_model.communication.BeaconRadio suitable for
 	// communicating with this train.

--- a/train_model/TrainModel.java
+++ b/train_model/TrainModel.java
@@ -46,6 +46,7 @@ public class TrainModel
 	private static final double DATASHEET_EDECEL_MPSPS  =  2.73;
 	private static final double DATASHEET_MID_SPEED_KPH = 35.00;
 	private static final double DATASHEET_MID_MASS_TON  = 50.00;
+	private static final double DATASHEET_POWER_WATT = 120e3;
 
 	// kilograms (constant for now)
 	private static final double MASS_EMPTY =
@@ -58,8 +59,7 @@ public class TrainModel
 		MASS_EMPTY * DATASHEET_ACCEL_MPSPS;
 
 	// watts, newtons
-	private static final double MAX_ENGINE_POWER =
-		DERIVED_MID_ENGINE_FORCE * DERIVED_MID_SPEED;
+	private static final double MAX_ENGINE_POWER = DATASHEET_POWER_WATT;
 	private static final double MAX_ENGINE_FORCE =
 		2.0 * DERIVED_MID_ENGINE_FORCE;
 

--- a/train_model/TrainModel.java
+++ b/train_model/TrainModel.java
@@ -195,6 +195,14 @@ public class TrainModel
 		return pointMass.orientation();
 	}
 
+	// Moves to the given pose instantaneously.
+	//
+	// Sets the speed to zero.
+	public void slew(Pose pose)
+	{
+		pointMass.slew(pose);
+	}
+
 	// Sets the orientation.
 	//
 	// Causes an instantaneous change in the direction of the velocity

--- a/train_model/communication/BeaconMessage.java
+++ b/train_model/communication/BeaconMessage.java
@@ -12,8 +12,8 @@ public class BeaconMessage
 {
 	// max legal length of beacon string
 	//
-	// TODO: BSed. What's the real value?
-	public static final int MAX_LENGTH = 80;
+	// 16 ASCII chars is 16 bytes * 8 bits per byte = 128 bits
+	public static final int MAX_LENGTH = 16;
 
 	public String string;
 

--- a/train_model/communication/Relay.java
+++ b/train_model/communication/Relay.java
@@ -28,12 +28,7 @@ public class Relay
 	private MboMovementCommand mboMessageLast =
 		new MboMovementCommand(0, 0);
 	private TrackMovementCommand trackMessageLast =
-		new TrackMovementCommand(
-			0,
-			new Authority(new boolean[] { false }),
-			new Authority(new boolean[] { false }),
-			new Authority(new boolean[] { false })
-		);
+		new TrackMovementCommand(0, 0);
 
 	// like most recent, but set to null after read
 	private BeaconMessage beaconMessageCached = null;

--- a/train_model/communication/TrackMovementCommand.java
+++ b/train_model/communication/TrackMovementCommand.java
@@ -6,8 +6,6 @@
 
 package train_model.communication;
 
-import track_controller.communication.Authority;
-
 // Instructions for a train's motion
 //
 // Sent by CTC via the track.
@@ -25,37 +23,23 @@ public class TrackMovementCommand
 	// Units: MPH (miles per hour)
 	public int speed;
 
-	// Blocks into which the train is allowed to move
+	// Distance allowed to travel before stopping
 	//
-	// From the POV of the track controller whose jurisdiction we are in
-	//
-	// NOTE: The train could be on any of the three branches and could be
-	// going in any direction. The train has the responsibility of figuring
-	// out where it is.
-	//
-	// A branch with zero length has null authority.
-	public Authority commonAuthority;
-	public Authority   leftAuthority;
-	public Authority  rightAuthority;
+	// Units: yard
+	public int authority;
 
 	// Constructs a TrackMovementCommand as a copy of another.
 	public TrackMovementCommand(TrackMovementCommand other)
 	{
 		this.speed = other.speed;
-
-		this.commonAuthority = other.commonAuthority;
-		this.  leftAuthority = other.  leftAuthority;
-		this. rightAuthority = other. rightAuthority;
+		this.authority = other.authority;
 	}
 
 	// Initializes all members.
 	//
 	// Throws IllegalArgumentException if any member initializer is
 	// invalid.
-	public TrackMovementCommand(int speed,
-	                            Authority commonAuthority,
-	                            Authority   leftAuthority,
-	                            Authority  rightAuthority)
+	public TrackMovementCommand(int speed, int authority)
 		throws IllegalArgumentException
 	{
 		if (speed < 0 || speed > MAX_SPEED)
@@ -64,14 +48,10 @@ public class TrackMovementCommand
 		if (speed % SPEED_MULTIPLE != 0)
 			throw new IllegalArgumentException("speed multiple");
 
-		if (commonAuthority == null)
-			throw new IllegalArgumentException(
-				"common authority null");
+		if (authority < 0)
+			throw new IllegalArgumentException("authority range");
 
 		this.speed = speed;
-
-		this.commonAuthority = commonAuthority;
-		this.  leftAuthority =   leftAuthority;
-		this. rightAuthority =  rightAuthority;
+		this.authority = authority;
 	}
 }

--- a/train_model/subsystem_demo/Main.java
+++ b/train_model/subsystem_demo/Main.java
@@ -24,7 +24,7 @@ public class Main
 	public static void main(String[] args)
 	{
 		TrackModel track = new TrackModel();
-		TrainModel train = new TrainModel();
+		TrainModel train = new TrainModel(1);
 		MBO mbo = new MBO();
 
 		// in real implemenation, won't be passing the train here

--- a/train_model/subsystem_demo/UI.java
+++ b/train_model/subsystem_demo/UI.java
@@ -100,13 +100,7 @@ public class UI
 
         trackRxSpeed.setText(String.format("%d mph", trackMessage.speed));
         trackRxAuthority.setText(
-		String.format(
-			"%2x / %2x / %2x",
-			boolArrayToInt(trackMessage.commonAuthority.blocks),
-			boolArrayToInt(trackMessage.  leftAuthority.blocks),
-			boolArrayToInt(trackMessage. rightAuthority.blocks)
-		)
-	);
+		String.format("%d y", trackMessage.authority));
 
         // TODO: use real interface for this
         mboTxLatitude.setText(String.format(

--- a/train_model/subsystem_demo/UI.java
+++ b/train_model/subsystem_demo/UI.java
@@ -829,7 +829,7 @@ public class UI
         /* Create and display the form */
         java.awt.EventQueue.invokeLater(new Runnable() {
             public void run() {
-                new UI(new TrainModel()).setVisible(true);
+                new UI(new TrainModel(0)).setVisible(true);
             }
         });
     }

--- a/train_model/subsystem_demo/track_model/TrackModel.java
+++ b/train_model/subsystem_demo/track_model/TrackModel.java
@@ -71,23 +71,7 @@ public class TrackModel implements Updateable
 		circuit.send(
 			new TrackMovementCommand(
 				10,
-				new Authority(
-					new boolean[] {  true,  true,  true }
-				),
-				trackCircuitState ?
-					new Authority(
-						new boolean[] {  true,  true }
-					) :
-					new Authority(
-						new boolean[] { false, false }
-					),
-				trackCircuitState ?
-					new Authority(
-						new boolean[] { false, false }
-					) :
-					new Authority(
-						new boolean[] {  true,  true }
-					)
+				trackCircuitState ? 10 : 20
 			)
 		);
 	}


### PR DESCRIPTION
 - `TrackMovementCommand` has scalar distance authority instead of boolean arrays
 - `TrainModel` can be slewed
 - `TrainModel` has an ID
 - `TrainModel` uses power from datasheet
 - `BeaconMessage` string length limited to 128 bits or 16 characters